### PR TITLE
[Chore] Update "actions/checkout"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     name: Verify cross references
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: serokell/xrefcheck-action@v1
       with:
         xrefcheck-version: 0.2.2
@@ -45,7 +45,7 @@ jobs:
             ghc: 8.4.4
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
     - uses: haskell/actions/setup@v2
@@ -84,7 +84,7 @@ jobs:
         ghc: ["8.8.3"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
     - uses: haskell/actions/setup@v2
@@ -110,6 +110,6 @@ jobs:
   reuse:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v1


### PR DESCRIPTION
Problem: node16 is now deprecated and github-runner provided by nixpkgs
no longer supports this runtime. However, "actions/checkout@v3" uses
this runtime.

Solution: Update CI pipeline to use "actions/checkout@v4".
